### PR TITLE
Fixed the issue that when tabs are switched, the pet component gets reinitialized

### DIFF
--- a/client/src/pet/controller.ts
+++ b/client/src/pet/controller.ts
@@ -240,4 +240,18 @@ export class PetController {
       this.lastUpdateTime = currentTime;
     }, 1000);
   }
+
+  /**
+   * Update the view callback function
+   * This allows reusing the controller instance with a new view component
+   * @param viewUpdateCallback New callback function
+   */
+  public updateCallback(viewUpdateCallback: (petId: PetId, state: PetState) => void): void {
+    this.viewUpdateCallback = viewUpdateCallback;
+    
+    // Notify the new callback about all existing pets
+    this.pets.forEach((pet, petId) => {
+      this.notifyViewUpdate(petId, pet.getState());
+    });
+  }
 }


### PR DESCRIPTION
When tabs are switched, the component unmounts and remounts, causing the PetController to be reinitialized. This issue is fixed, now, the pet state will persist correctly when switching tabs and there won't be multiple update intervals running simultaneously, which improves user experience since pets won't "reset" when returning to the tab.