### PR TITLE
Pomodoro close button in dashboard

### DIFF
--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -5,6 +5,8 @@ declare global {
     electronAPI?: {
       openPomodoroWindow: () => void;
       openPetWindow: () => void;
+      closePomodoroWindow: () => void;
+      isPomodoroWindowOpen: () => Promise<boolean>;
 
       openOrFocusMainHome: () => Promise<void>;
 

--- a/client/src/home-page/tests/view.test.tsx
+++ b/client/src/home-page/tests/view.test.tsx
@@ -103,18 +103,6 @@ describe('View component - Pomodoro button', () => {
     };
   });
 
-  it('calls electronAPI.openPomodoroWindow when Pomodoro start button is clicked', () => {
-    render(
-      <MemoryRouter>
-        <View />
-      </MemoryRouter>,
-    );
-
-    const startButton = screen.getByRole('button');
-    fireEvent.click(startButton);
-
-    expect(window.electronAPI.openPomodoroWindow).toHaveBeenCalledTimes(1);
-  });
 
   // Stat card tests
   describe('View component - Stats and To Do list', () => {
@@ -160,4 +148,95 @@ describe('View component - Pomodoro button', () => {
   });
 });
 
+
+  // Pomodoro Timer tests
+
+  it('calls electronAPI.openPomodoroWindow when Pomodoro start button is clicked', () => {
+    render(
+      <MemoryRouter>
+        <View />
+      </MemoryRouter>,
+    );
+
+    const startButton = screen.getByRole('button');
+    fireEvent.click(startButton);
+
+    expect(window.electronAPI.openPomodoroWindow).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Start Pomodoro Timer" initially when window is closed', async () => {
+    (window as any).electronAPI.isPomodoroWindowOpen = vi.fn().mockResolvedValue(false);
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <View />
+        </MemoryRouter>
+      );
+    });
+
+    expect(screen.getByText('Start Pomodoro Timer')).toBeTruthy();
+  });
+
+  it('shows "Close Pomodoro Timer" initially when window is open', async () => {
+    (window as any).electronAPI.isPomodoroWindowOpen = vi.fn().mockResolvedValue(true);
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <View />
+        </MemoryRouter>
+      );
+    });
+
+    expect(screen.getByText('Close Pomodoro Timer')).toBeTruthy();
+  });
+
+  it('calls openPomodoroWindow when button clicked if Pomodoro is closed, and changes text', async () => {
+    (window as any).electronAPI.isPomodoroWindowOpen = vi.fn().mockResolvedValue(false);
+    (window as any).electronAPI.openPomodoroWindow = vi.fn();
+    (window as any).electronAPI.closePomodoroWindow = vi.fn();
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <View />
+        </MemoryRouter>
+      );
+    });
+
+    const button = screen.getByRole('button');
+    expect(screen.getByText('Start Pomodoro Timer')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(window.electronAPI.openPomodoroWindow).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Close Pomodoro Timer')).toBeTruthy();
+  });
+
+  it('calls closePomodoroWindow when button clicked if Pomodoro is open, and changes text', async () => {
+    (window as any).electronAPI.isPomodoroWindowOpen = vi.fn().mockResolvedValue(true);
+    (window as any).electronAPI.openPomodoroWindow = vi.fn();
+    (window as any).electronAPI.closePomodoroWindow = vi.fn();
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <View />
+        </MemoryRouter>
+      );
+    });
+
+    const button = screen.getByRole('button');
+    expect(screen.getByText('Close Pomodoro Timer')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(window.electronAPI.closePomodoroWindow).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Start Pomodoro Timer')).toBeTruthy();
+  });
 });

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -255,13 +255,7 @@ const createPetWindow = async (): Promise<void> => {
   });
 };
 
-ipcMain.on('open-pomodoro-window', async () => {
-  await createPomodoroWindow();
-});
 
-ipcMain.on('open-pet-window', async () => {
-  await createPetWindow();
-});
 
 const getFilePath = (filename: string) =>
   app.isPackaged ? `${app.getAppPath()}/data/${filename}` : `data/${filename}`;
@@ -347,6 +341,29 @@ ipcMain.on('deleteDoc', async (e, {filename, query}: DbRemoveConfig) => {
 
 
 // Pomodoro handlers
+ipcMain.on('open-pomodoro-window', async () => {
+  await createPomodoroWindow();
+});
+
+ipcMain.on('open-pet-window', async () => {
+  await createPetWindow();
+});
+
+ipcMain.on('close-pomodoro-window', () => {
+  if (pomodoroWindow) {
+    pomodoroWindow.close();
+    pomodoroWindow = null;
+  }
+});
+
+
+function isPomodoroWindowOpen() {
+  return pomodoroWindow !== null && !pomodoroWindow.isDestroyed();
+}
+ipcMain.handle('is-pomodoro-window-open', () => {
+  return isPomodoroWindowOpen();
+});
+
 
 ipcMain.on('increment-focus-count', async () => {
   const db = getDbInstance('pomodoro.db') as TypedDatastore<PomodoroStats>;

--- a/client/src/preload.ts
+++ b/client/src/preload.ts
@@ -30,7 +30,9 @@ contextBridge.exposeInMainWorld('electron', {
 
 contextBridge.exposeInMainWorld('electronAPI', {
   openPomodoroWindow: () => ipcRenderer.send('open-pomodoro-window'),
+  closePomodoroWindow: () => ipcRenderer.send('close-pomodoro-window'),
   openPetWindow: () => ipcRenderer.send('open-pet-window'),
+  isPomodoroWindowOpen: () => ipcRenderer.invoke('is-pomodoro-window-open'),
 
   // Expose the openOrFocusMainHome method (ipc invoke)
   openOrFocusMainHome: () => ipcRenderer.invoke('open-or-focus-main-home'),


### PR DESCRIPTION
Updated the start pomodoro timer button in dashboard to allow users to close the window.
Added tests to verify that the close/start button and label correctly displays the current state of the Pomodoro window when reloading dashboard.